### PR TITLE
Exclude Supabase likes docs from sitemap and crawlers

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,9 @@ supabase_publishable_key: "sb_publishable_dxlmntuz2OVBpoXfp6Z8Ig_0UFJK-TH"
 # Build settings
 markdown: kramdown
 
+exclude:
+  - supabase
+
 include: [".well-known", "manifest.json", "sw.js"]
 
 plugins:

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /supabase/
+
+Sitemap: https://www.derekcroote.com/sitemap.xml


### PR DESCRIPTION
The supabase/README.md setup page was being published at /supabase/ and included in sitemap.xml. Exclude the supabase directory from the Jekyll build and add robots.txt rules so crawlers do not index or follow links under /supabase/.