### PR TITLE
Fix oversized CC license icons in RSS full read mode

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -24,9 +24,9 @@ layout: default
         Croote</a>
       is licensed under
       <a rel="license" href="https://creativecommons.org/licenses/by-nc/4.0">CC BY-NC 4.0<img
-          class="license-icon" src="/images/cc.svg" alt="Creative Commons Icon" /><img
-          class="license-icon" src="/images/by.svg" alt="Creative Commons Attribution Icon" /><img
-          class="license-icon" src="/images/nc.svg" alt="Creative Commons Noncommercial Icon" /></a>
+          class="license-icon" src="/images/cc.svg" alt="Creative Commons Icon" width="20" height="20" /><img
+          class="license-icon" src="/images/by.svg" alt="Creative Commons Attribution Icon" width="20" height="20" /><img
+          class="license-icon" src="/images/nc.svg" alt="Creative Commons Noncommercial Icon" width="20" height="20" /></a>
     </p>   
 
   </article>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -530,7 +530,10 @@ li {
 }
 
 .license-icon {
+  width: 20px;
   height: 20px;
+  max-width: none;
+  display: inline;
   margin-left: 4px;
   vertical-align: text-bottom;
 }


### PR DESCRIPTION
Add explicit width/height attributes on license icon images so they stay 20px when RSS readers strip site CSS. Also strengthen .license-icon with width and max-width: none to prevent global img rules from scaling them up on the live site.