### PR TITLE
Add UTM parameters to RSS feed links for traffic attribution

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -29,7 +29,7 @@ layout: null
           <description>{{ post.content | xml_escape }}</description>
         {% endif %}
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
-        <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
+        <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}?utm_source=rss&amp;utm_medium=feed</link>
         <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
         {% for tag in post.tags %}
         <category>{{ tag | xml_escape }}</category>


### PR DESCRIPTION
Append utm_source=rss and utm_medium=feed to post links in feed.xml to identify click-throughs from RSS readers.