### PR TITLE
Fix invalid Schema.org image alt metadata

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -66,10 +66,4 @@
   <meta property="og:image:alt" content="{{ page.image-alt | escape }}" />
   <meta name="twitter:image:alt" content="{{ page.image-alt | escape }}" />
   {% endif %}
-  {% if page.image_width %}
-  <meta property="og:image:width" content="{{ page.image_width }}" />
-  {% endif %}
-  {% if page.image_height %}
-  <meta property="og:image:height" content="{{ page.image_height }}" />
-  {% endif %}
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -59,4 +59,17 @@
   <meta name="robots" content="noindex, follow" />
   {% endif %}
   {% seo %}
+  {% comment %}
+  Keep image-alt separate from Jekyll SEO Tag's image object because Schema.org ImageObject has no alt property.
+  {% endcomment %}
+  {% if page.image-alt %}
+  <meta property="og:image:alt" content="{{ page.image-alt | escape }}" />
+  <meta name="twitter:image:alt" content="{{ page.image-alt | escape }}" />
+  {% endif %}
+  {% if page.image_width %}
+  <meta property="og:image:width" content="{{ page.image_width }}" />
+  {% endif %}
+  {% if page.image_height %}
+  <meta property="og:image:height" content="{{ page.image_height }}" />
+  {% endif %}
 </head>

--- a/about.md
+++ b/about.md
@@ -3,11 +3,10 @@ layout: page
 title: About Derek Croote
 description: Find out more about Derek Croote as well as ways to connect.
 permalink: /about/
-image:
-  path: /images/og-image.png
-  width: 1200
-  height: 630
-  alt: About Derek Croote
+image: /images/og-image.png
+image-alt: About Derek Croote
+image_width: 1200
+image_height: 630
 ---
 
 <p>Thanks for visiting the site! You can find social profiles, project links, and flavors of my bio below. </p>

--- a/about.md
+++ b/about.md
@@ -7,7 +7,7 @@ image:
   path: /images/og-image.png
   width: 1200
   height: 630
-image-alt: Blog by Derek Croote. Science, engineering, and data. Sometimes with humor.
+image-alt: Black-and-white headshot of Derek Croote beside the title Blog by Derek Croote; beneath it, Science, engineering, and data. Sometimes with humor. derekcroote.com appears below on a dark gray background.
 ---
 
 <p>Thanks for visiting the site! You can find social profiles, project links, and flavors of my bio below. </p>

--- a/about.md
+++ b/about.md
@@ -7,7 +7,7 @@ image:
   path: /images/og-image.png
   width: 1200
   height: 630
-image-alt: Black-and-white headshot of Derek Croote beside the title Blog by Derek Croote; beneath it, Science, engineering, and data. Sometimes with humor. derekcroote.com appears below on a dark gray background.
+image-alt: Black-and-white headshot of Derek Croote beside Blog by Derek Croote and the tagline Science, engineering, and data. Sometimes with humor.
 ---
 
 <p>Thanks for visiting the site! You can find social profiles, project links, and flavors of my bio below. </p>

--- a/about.md
+++ b/about.md
@@ -7,7 +7,7 @@ image:
   path: /images/og-image.png
   width: 1200
   height: 630
-image-alt: Portrait of Derek Croote alongside the title "Blog by Derek Croote" and the tagline "Science, engineering, and data. Sometimes with humor."
+image-alt: Portrait of Derek Croote for his blog on science, engineering, and data. Sometimes with humor.
 ---
 
 <p>Thanks for visiting the site! You can find social profiles, project links, and flavors of my bio below. </p>

--- a/about.md
+++ b/about.md
@@ -7,7 +7,7 @@ image:
   path: /images/og-image.png
   width: 1200
   height: 630
-image-alt: Portrait of Derek Croote for his blog on science, engineering, and data. Sometimes with humor.
+image-alt: Blog by Derek Croote. Science, engineering, and data. Sometimes with humor.
 ---
 
 <p>Thanks for visiting the site! You can find social profiles, project links, and flavors of my bio below. </p>

--- a/about.md
+++ b/about.md
@@ -3,10 +3,11 @@ layout: page
 title: About Derek Croote
 description: Find out more about Derek Croote as well as ways to connect.
 permalink: /about/
-image: /images/og-image.png
+image:
+  path: /images/og-image.png
+  width: 1200
+  height: 630
 image-alt: About Derek Croote
-image_width: 1200
-image_height: 630
 ---
 
 <p>Thanks for visiting the site! You can find social profiles, project links, and flavors of my bio below. </p>

--- a/about.md
+++ b/about.md
@@ -7,7 +7,7 @@ image:
   path: /images/og-image.png
   width: 1200
   height: 630
-image-alt: About Derek Croote
+image-alt: Portrait of Derek Croote alongside the title "Blog by Derek Croote" and the tagline "Science, engineering, and data. Sometimes with humor."
 ---
 
 <p>Thanks for visiting the site! You can find social profiles, project links, and flavors of my bio below. </p>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@ image:
   path: /images/og-image.png
   width: 1200
   height: 630
-image-alt: Blog by Derek Croote. Science, engineering, and data. Sometimes with humor.
+image-alt: Black-and-white headshot of Derek Croote beside the title Blog by Derek Croote; beneath it, Science, engineering, and data. Sometimes with humor. derekcroote.com appears below on a dark gray background.
 ---
 
 <div class="home">

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@ image:
   path: /images/og-image.png
   width: 1200
   height: 630
-image-alt: Blog by Derek Croote
+image-alt: Portrait of Derek Croote alongside the title "Blog by Derek Croote" and the tagline "Science, engineering, and data. Sometimes with humor."
 ---
 
 <div class="home">

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@ image:
   path: /images/og-image.png
   width: 1200
   height: 630
-image-alt: Black-and-white headshot of Derek Croote beside the title Blog by Derek Croote; beneath it, Science, engineering, and data. Sometimes with humor. derekcroote.com appears below on a dark gray background.
+image-alt: Black-and-white headshot of Derek Croote beside Blog by Derek Croote and the tagline Science, engineering, and data. Sometimes with humor.
 ---
 
 <div class="home">

--- a/index.html
+++ b/index.html
@@ -1,9 +1,10 @@
 ---
 layout: default
-image: /images/og-image.png
+image:
+  path: /images/og-image.png
+  width: 1200
+  height: 630
 image-alt: Blog by Derek Croote
-image_width: 1200
-image_height: 630
 ---
 
 <div class="home">

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@ image:
   path: /images/og-image.png
   width: 1200
   height: 630
-image-alt: Portrait of Derek Croote for his blog on science, engineering, and data. Sometimes with humor.
+image-alt: Blog by Derek Croote. Science, engineering, and data. Sometimes with humor.
 ---
 
 <div class="home">

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@ image:
   path: /images/og-image.png
   width: 1200
   height: 630
-image-alt: Portrait of Derek Croote alongside the title "Blog by Derek Croote" and the tagline "Science, engineering, and data. Sometimes with humor."
+image-alt: Portrait of Derek Croote for his blog on science, engineering, and data. Sometimes with humor.
 ---
 
 <div class="home">

--- a/index.html
+++ b/index.html
@@ -1,10 +1,9 @@
 ---
 layout: default
-image:
-  path: /images/og-image.png
-  width: 1200
-  height: 630
-  alt: Blog by Derek Croote
+image: /images/og-image.png
+image-alt: Blog by Derek Croote
+image_width: 1200
+image_height: 630
 ---
 
 <div class="home">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep valid social image `path`, `width`, and `height` fields in the Schema.org `ImageObject`
- move only alt text out of the image object so Jekyll SEO Tag does not serialize unsupported `ImageObject.alt`
- concisely describe the headshot, blog title, and tagline in Open Graph and Twitter alt metadata

## Test plan
- build the Jekyll site
- validate generated JSON-LD and social image metadata
- verify the image description is preserved in generated metadata
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4efca1c9-c709-483c-8467-eba540b6db9f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4efca1c9-c709-483c-8467-eba540b6db9f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

